### PR TITLE
removed password complexity restrictions as per NIST guidelines

### DIFF
--- a/app/Resources/translations/validators.en.yml
+++ b/app/Resources/translations/validators.en.yml
@@ -5,7 +5,7 @@ form_errors:
   max_length: This field cannot be longer than {{ limit }} characters.
   min_length: This field must contain at least {{ limit }} characters.
   not_blank: This field cannot be empty.
-  password_strength: Your password must be at least 8 characters long and contain a digit, a lowercase and an uppercase.
+  password_length: Your password must be between 8 and 50 characters.
   repeat_password: The password fields must match.
   unique_email: This email is already used.
   unique_username: This username is already used.

--- a/src/AppBundle/Entity/User.php
+++ b/src/AppBundle/Entity/User.php
@@ -79,9 +79,11 @@ class User implements UserInterface, AdvancedUserInterface, EquatableInterface
      * @Assert\NotBlank(
      *     message="form_errors.not_blank",
      * )
-     * @Assert\Regex(
-     *     pattern = "/^(?=\D*\d)(?=[^a-z]*[a-z])(?=[^A-Z]*[A-Z])[\w~@#$%^&*+=`|{}:;!.?""''()\[\]-]{8,50}$/",
-     *     message = "form_errors.password_strength",
+     * @Assert\Length(
+     *     min=8,
+     *     max=150,
+     *     minMessage="form_errors.password_length",
+     *     maxMessage="form_errors.password_length",
      * )
      * @CustomAssert\BreachedPassword()
      *


### PR DESCRIPTION
only min length is enforced, max length is to comply with bcrypt limitations (72 bytes max length)